### PR TITLE
Change permission of /run/munge 0700 to 0755

### DIFF
--- a/_pages/hpc/installationslurm.md
+++ b/_pages/hpc/installationslurm.md
@@ -73,9 +73,11 @@ $ cexec cp /home/munge.key /etc/munge {% endhighlight %}
 #### Mettre les droits:
 
  {% highlight bash %}$ chown -R munge: /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/
-$ chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/
+$ chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/
+$ chmod 0755 /run/munge/
 $ cexec chown -R munge: /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/
-$ cexec chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/ /run/munge/{% endhighlight %}
+$ cexec chmod 0700 /etc/munge/ /var/log/munge/ /var/lib/munge/
+$ cexec chmod 0755 /run/munge/{% endhighlight %}
 
 #### Activer et démarrer le service munge service:
 


### PR DESCRIPTION
Thank you for your helpful documents.
On CentOS 7.9.2009,
I found "chmod 0700 /run/munge" leads to the error below:
munged: Error: Socket is inaccessible: execute permissions for all required on "/run/munge"

and,
"chmod 0755 /run/munge" fix above error.